### PR TITLE
Added a Stats Page Class that prints 'hello world'

### DIFF
--- a/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/StatsPageServlet.java
@@ -1,0 +1,22 @@
+package com.google.codeu.servlets;
+
+import java.io.IOException;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Responds with a hard-coded message for testing purposes.
+ */
+@WebServlet("/stats")
+public class StatsPageServlet extends HttpServlet{
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+
+        response.getOutputStream().println("hello world");
+    }
+}


### PR DESCRIPTION
If you go to the following link you can see the beginning of a stats page. For now it just says hello world.

![image](https://user-images.githubusercontent.com/29261648/52991220-02cdde00-33c9-11e9-9031-6487f2e73ce5.png)



